### PR TITLE
Added a Unity Action per frame after transform completion

### DIFF
--- a/Assets/JigglePhysics/Scripts/JiggleRigBuilder.cs
+++ b/Assets/JigglePhysics/Scripts/JiggleRigBuilder.cs
@@ -236,7 +236,7 @@ public class JiggleRigBuilder : MonoBehaviour {
         CachedSphereCollider.FinishedPass();
         wasLODActive = true;
 
-        FinishedPass.Invoke();
+        FinishedPass?.Invoke();
     }
 
     public JiggleRig GetJiggleRig(Transform rootTransform) {

--- a/Assets/JigglePhysics/Scripts/JiggleRigBuilder.cs
+++ b/Assets/JigglePhysics/Scripts/JiggleRigBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.Serialization;
 
 namespace JigglePhysics {
@@ -171,6 +172,9 @@ public class JiggleRigBuilder : MonoBehaviour {
     [Tooltip("Draws some simple lines to show what the simulation is doing. Generally this should be disabled.")]
     [SerializeField] private bool debugDraw;
 
+    [Tooltip("An event that occurs after the Jiggle Rig Builder is done moving all the bones for the frame.")]
+    public UnityAction FinishedPass;
+
     private double accumulation;
     private bool dirtyFromEnable = false;
     private bool wasLODActive = true;
@@ -231,6 +235,8 @@ public class JiggleRigBuilder : MonoBehaviour {
         }
         CachedSphereCollider.FinishedPass();
         wasLODActive = true;
+
+        FinishedPass.Invoke();
     }
 
     public JiggleRig GetJiggleRig(Transform rootTransform) {

--- a/Assets/JigglePhysics/Scripts/JiggleSkin.cs
+++ b/Assets/JigglePhysics/Scripts/JiggleSkin.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.Serialization;
 
 namespace JigglePhysics {
@@ -44,6 +45,9 @@ public class JiggleSkin : MonoBehaviour {
 
     private bool wasLODActive = true;
     private double accumulation;
+
+    [Tooltip("An event that occurs after the Jiggle Skin is done moving the skin for the frame.")]
+    public UnityAction FinishedPass;
 
     private List<Material> targetMaterials;
     private List<Vector4> packedVectors;
@@ -132,6 +136,8 @@ public class JiggleSkin : MonoBehaviour {
         foreach( JiggleZone zone in jiggleZones) {
             zone.DebugDraw();
         }
+
+        FinishedPass.Invoke();
     }
 
     private void LateUpdate() {

--- a/Assets/JigglePhysics/Scripts/JiggleSkin.cs
+++ b/Assets/JigglePhysics/Scripts/JiggleSkin.cs
@@ -137,7 +137,7 @@ public class JiggleSkin : MonoBehaviour {
             zone.DebugDraw();
         }
 
-        FinishedPass.Invoke();
+        FinishedPass?.Invoke();
     }
 
     private void LateUpdate() {


### PR DESCRIPTION
This new Unity Action which executes every frame after the bone transforms are all completed allows developers to hook into it to then do even more transform changes if needed.

For example, this is necessary if you have a Charmander with its tail having Jiggle Physics, but want the flame to not be parented to the tail bone itself.