### PR TITLE
Guard against destroyed Transforms during jiggle tree regeneration

### DIFF
--- a/Packages/com.gator-dragon-games.jigglephysics/Scripts/JigglePhysics.cs
+++ b/Packages/com.gator-dragon-games.jigglephysics/Scripts/JigglePhysics.cs
@@ -198,14 +198,23 @@ public static class JigglePhysics {
 
     private static void GetJiggleTrees() {
         Profiler.BeginSample("JiggleRoot.GetJiggleTrees");
-        // TODO: Cleanup previous trees, or reuse them.
-        foreach (var rootJiggleTreeSegment in rootJiggleTreeSegments) {
-            var currentTree = rootJiggleTreeSegment.jiggleTree;
+        // Prune any segments whose root Transform has been destroyed out-of-band
+        // (e.g. asset bundle unload, scene teardown, or a rig whose OnDisable was
+        // skipped) before attempting to regenerate their trees.
+        for (int i = rootJiggleTreeSegments.Count - 1; i >= 0; i--) {
+            var seg = rootJiggleTreeSegments[i];
+            if (seg.transform == null || seg.jiggleRigData.rootBone == null) {
+                if (seg.jiggleTree != null) ScheduleRemoveJiggleTree(seg.jiggleTree);
+                jiggleRootLookup.Remove(seg.transform);
+                rootJiggleTreeSegments.RemoveAt(i);
+                continue;
+            }
+            var currentTree = seg.jiggleTree;
             if (currentTree is { dirty: false }) {
                 continue;
             }
-            rootJiggleTreeSegment.RegenerateJiggleTreeIfNeeded();
-            jobs.ScheduleAdd(rootJiggleTreeSegment.jiggleTree);
+            seg.RegenerateJiggleTreeIfNeeded();
+            jobs.ScheduleAdd(seg.jiggleTree);
         }
         Profiler.EndSample();
     }
@@ -260,7 +269,7 @@ public static class JigglePhysics {
     }
 
     public static void VisitForLength(Transform t, JiggleRigData rig, Vector3 lastPosition, float currentLength, out float totalLength) {
-        if (rig.GetIsExcluded(t)) {
+        if (t == null || rig.GetIsExcluded(t)) {
             totalLength = Mathf.Max(currentLength, 0.001f);
             return;
         }
@@ -275,6 +284,10 @@ public static class JigglePhysics {
     }
 
     private static void Visit(Transform t, List<Transform> transforms, List<JiggleSimulatedPoint> points, List<JigglePointParameters> parameters, List<Vector3> restLocalPositions, List<Quaternion> restLocalRotations, int parentIndex, JiggleRigData lastJiggleRig, Vector3 lastPosition, float currentLength, out int newIndex) {
+        if (t == null) {
+            newIndex = -1;
+            return;
+        }
         if (Application.isPlaying && GetJiggleTreeSegmentByBone(t, out JiggleTreeSegment currentJiggleTreeSegment)) {
             lastJiggleRig = currentJiggleTreeSegment.jiggleRigData;
         }

--- a/Packages/com.gator-dragon-games.jigglephysics/Scripts/JiggleRigData.cs
+++ b/Packages/com.gator-dragon-games.jigglephysics/Scripts/JiggleRigData.cs
@@ -154,7 +154,7 @@ public struct JiggleRigData {
     }
     
     private void VisitAndSetCacheData(List<JiggleTransformCachedData> data, Transform t, Vector3 lastPosition, float currentLength, float totalLength) {
-        if (GetIsExcluded(t)) {
+        if (t == null || GetIsExcluded(t)) {
             return;
         }
         var validChildrenCount = GetValidChildrenCount(t);
@@ -176,21 +176,24 @@ public struct JiggleRigData {
     }
 
     public int GetValidChildrenCount(Transform t) {
+        if (t == null) return 0;
         int count = 0;
         var childCount = t.childCount;
         for(int i=0;i<childCount;i++) {
-            if (GetIsExcluded(t.GetChild(i))) continue;
+            var child = t.GetChild(i);
+            if (child == null || GetIsExcluded(child)) continue;
             count++;
         }
         return count;
     }
 
     public Transform GetValidChild(Transform t, int index) {
+        if (t == null) return null;
         int count = 0;
         var childCount = t.childCount;
         for(int i=0;i<childCount;i++) {
             var child = t.GetChild(i);
-            if (GetIsExcluded(child)) continue;
+            if (child == null || GetIsExcluded(child)) continue;
             if (count == index) {
                 return child;
             }


### PR DESCRIPTION
## Summary

Guards the tree-construction path against destroyed `Transform` references so that a rig whose bones get destroyed out-of-band doesn't crash the next frame's `GetJiggleTrees` pass on `t.childCount`.

`JiggleTree.ResetTransformsToRest` already applies this defensive pattern (`if (!bone) continue;`) — this PR extends the same discipline to the construction path.

## Reproduction

Hit in the wild by the BasisVR framework during avatar swaps. Stack trace:

```
MissingReferenceException: The object of type 'UnityEngine.Transform' has been destroyed but you are still trying to access it.
  at JiggleRigData.GetValidChildrenCount (Transform t)   // t.childCount
  at JigglePhysics.CreateJiggleTree (JiggleRigData, JiggleTree)
  at JiggleTreeSegment.RegenerateJiggleTreeIfNeeded ()
  at JigglePhysics.GetJiggleTrees ()
  at JigglePhysics.GetJiggleJobs (...)
  at JigglePhysics.ScheduleSimulate (...)
  at <host>.LateUpdate ()
```

A `JiggleTreeSegment` can remain registered in `rootJiggleTreeSegments` after its `rootBone` is destroyed when:

- A `GameObject` holding bones is destroyed but its `JiggleRig.OnDisable` did not fire first (scene unload ordering, bundle refcount hitting zero mid-frame, `JIGGLEPHYSICS_DISABLE_ON_DISABLE` set).
- A descendant bone is destroyed while the `JiggleRig` itself stays enabled.

Unity's `Object == null` overload handles fake-null, but direct property access (`t.childCount`, `t.position`) throws.

## Changes

**`JigglePhysics.cs`**

- `GetJiggleTrees` — iterate in reverse and prune segments whose `transform` / `rootBone` has been destroyed. Dead segments get their tree scheduled for removal, get removed from `rootJiggleTreeSegments` and `jiggleRootLookup`, and the loop continues. The system self-heals on the next frame instead of re-throwing every LateUpdate.
- `Visit` — bail with `newIndex = -1` on a null `t` (matches the convention already used when no new point is produced).
- `VisitForLength` — return early on null `t` (preserves the current `currentLength` semantics for the bail path).

**`JiggleRigData.cs`**

- `GetValidChildrenCount` — return `0` on null parent; skip null children. This keeps it in lock-step with `GetValidChild`, which the loops downstream rely on.
- `GetValidChild` — return `null` on null parent; skip null children.
- `VisitAndSetCacheData` — bail on null `t`.

## Scope / non-goals

- No behavior change for rigs with live transforms. The healthy path only picks up a handful of extra null-checks.
- This doesn't try to answer *why* a given rig ended up with a dead transform — that's framework-side. This just makes the package robust to it.